### PR TITLE
Update ohkami to v0.18

### DIFF
--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -14,5 +14,5 @@ DEBUG = ["dep:console_error_panic_hook"]
 
 [dependencies]
 console_error_panic_hook = { version = "0.1.7", optional = true }
-ohkami = { version = "0.17", features = ["rt_worker"] }
+ohkami = { version = "0.18", features = ["rt_worker"] }
 worker = { version = "0.1.0" }

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -1,5 +1,8 @@
 use ohkami::prelude::*;
 
+#[ohkami::bindings]
+struct Bindings;
+
 #[ohkami::worker]
 async fn my_worker() -> Ohkami {
     #[cfg(feature = "DEBUG")]

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,6 +1,6 @@
 name = "ohkami-worker"
 main = "build/worker/shim.mjs"
-compatibility_date = "2024-04-20"
+compatibility_date = "2024-05-03"
 
 [build]
 command = "cargo install -q worker-build && worker-build --release"


### PR DESCRIPTION
- Update ohkami version: `0.17` → `0.18`
- Update compatibility_date
- Add `#[bindings] struct Bindings;` to default `lib.rs`