### PR TITLE
chore: update build-dispatching method and update docs

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -2,21 +2,22 @@
 
 ## Prerequisites
 
-- Rust toolchain of latest version with `wasm32-unknown-unknown` target
+- Rust toolchain of channel `1.81` with `wasm32-unknown-unknown` target
+- [`worker-build`](https://crates.io/crates/worker-build) ( run `cargo install worker-build` to install )
 - npm
 
-In addition, `wasm-opt` is recommended to be installed.
+In addition, `wasm-opt` ( pakcaged in [binaryen](https://github.com/WebAssembly/binaryen) ) is recommended to be installed for release build optimization.
 
 ## Setup
 
 ```sh
-npm create cloudflare ./path/to/project-dir -- --template https://github.com/ohkami-rs/ohkami-templates/worker
+npm create cloudflare ＜project dir＞ -- --template https://github.com/ohkami-rs/ohkami-templates/worker
 ```
 ```sh
-cd ./path/to/project-dir
+cd ＜project dir＞
 ```
 
-and if you push the project to your GitHub repo, **You should add `wrangler.toml` into .gitignore**！
+If you push the project to your GitHub repo, **you should add `wrangler.toml` into .gitignore**！
 
 ## Local dev
 

--- a/worker/package.json
+++ b/worker/package.json
@@ -3,8 +3,8 @@
 	"version": "0.1.0",
 	"private": true,
 	"scripts": {
-		"deploy": "wrangler deploy",
-		"dev": "wrangler dev --env dev"
+		"deploy": "export OHKAMI_WORKER_DEV='' && wrangler deploy",
+		"dev": "export OHKAMI_WORKER_DEV=1 && wrangler dev"
 	},
 	"devDependencies": {
 		"wrangler": "^3.50"

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -2,7 +2,7 @@ name = "ohkami-worker"
 main = "build/worker/shim.mjs"
 compatibility_date = "2024-05-09"
 
-build = { command = "cargo install -q worker-build && worker-build --release" }
+# `worker-build` is required (run `cargo install worker-build` to install)
 
-[env.dev]
-build = { command = "cargo install -q worker-build && worker-build --dev" }
+[build]
+command = "test $OHKAMI_WORKER_DEV && worker-build --dev || worker-build"

--- a/worker_yew_spa/README.md
+++ b/worker_yew_spa/README.md
@@ -2,27 +2,25 @@
 
 ## Prerequisites
 
-- Latest Rust toolchain with `wasm32-unknown-unknown` target
+- Rust toolchain of channel `1.81` with `wasm32-unknown-unknown` target
+- [`worker-build`](https://crates.io/crates/worker-build) ( run `cargo install worker-build` to install )
 - npm
-- `trunk` CLI ( installable by `cargo install trunk` )
+- `trunk` CLI ( run `cargo install trunk` to install )
 
-In addition, `wasm-opt` is recommended to be installed.
+In addition, `wasm-opt` ( pakcaged in [binaryen](https://github.com/WebAssembly/binaryen) ) is recommended to be installed for release build optimization.
 
 See https://github.com/kanarus/ohkami-yew-todo for a working example!
 
 ## Setup
 
 ```sh
-npm create cloudflare ./path/to/project-dir -- --template https://github.com/ohkami-rs/ohkami-templates/worker_yew_spa
+npm create cloudflare ＜project dir＞ -- --template https://github.com/ohkami-rs/ohkami-templates/worker_yew_spa
 ```
 ```sh
-cd ./path/to/project-dir
-```
-```sh
-npx wrangler login
+cd ＜project dir＞
 ```
 
-If you push the project to your GitHub repo, **You should add `wrangler.toml` into .gitignore**！
+If you push the project to your GitHub repo, **you should add `wrangler.toml` into .gitignore**！
 
 ## Local dev
 
@@ -35,6 +33,9 @@ trunk serve --watch src/ui --open
 
 ## Publish
 
+```sh
+npx wrangler login
+```
 ```sh
 npm run deploy
 ```

--- a/worker_yew_spa/package.json
+++ b/worker_yew_spa/package.json
@@ -3,8 +3,8 @@
 	"version": "0.1.0",
 	"private": true,
 	"scripts": {
-		"deploy": "trunk build --release && wrangler deploy --assets dist",
-		"dev": "wrangler dev --env dev --port 8787"
+		"deploy": "export OHKAMI_WORKER_DEV='' && trunk build --release && wrangler deploy --assets dist",
+		"dev": "export OHKAMI_WORKER_DEV=1 && wrangler dev --env dev --port 8787"
 	},
 	"devDependencies": {
 		"wrangler": "^3.50"

--- a/worker_yew_spa/wrangler.toml
+++ b/worker_yew_spa/wrangler.toml
@@ -2,10 +2,10 @@ name = "worker_yew_spa"
 main = "build/worker/shim.mjs"
 compatibility_date = "2024-04-19"
 
+# `worker-build` is required (run `cargo install worker-build` to install)
+
 # `trunk` CLI is required
 
-build = { command = "cargo install -q worker-build && worker-build --release" }
-
-[env.dev]
-build = { command = "cargo install -q worker-build && worker-build --dev" }
-# then run `trunk serve --watch src/ui --open` in another terminal window
+[build]
+command = "test $OHKAMI_WORKER_DEV && worker-build --dev || worker-build"
+# in dev, run `trunk serve --watch src/ui --open` in another terminal window


### PR DESCRIPTION
Use an exported environment variable `OHKAMI_WORKER_DEV` to dispatch `worker-build --dev` or `worker-build`.

Before it was achieved by `env` of worker like:

*wrangler.toml*
```toml
build = { command = "worker-build" }

[env.dev]
biuld = { command = "worker-build --dev" }
```

But this is very annoying when to add bindings ( KV, D1, ... ) because we **have to write them _twice_** to just apply them to `dev` environment:

*wrangler.toml*
```toml
build = { command = "worker-build" }
d1_databases = [
    { binding = "DB", preview_database_id = "DB", database_name = "DB", database_id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" }
]

[env.dev]
biuld = { command = "worker-build --dev" }
d1_databases = [
    { binding = "DB", preview_database_id = "DB", database_name = "DB", database_id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" }
]
```

Again, this is very annoying.

So this PR introduces an environment variable `OHKAMI_WORKER_DEV` and dispatch build commands by if it's empty or not:

*wrangler.toml*
```toml
[build]
command = "test $OHKAMI_WORKER_DEV && worker-build --dev || worker-build"
```

and export it in npm scripts:

*package.json*
```jsonc
// 〜

"scripts": {
    "deploy": "wrangler deploy",
    "dev": "wrangler dev --env dev"
    "deploy": "export OHKAMI_WORKER_DEV='' && wrangler deploy",
    "dev": "export OHKAMI_WORKER_DEV=1 && wrangler dev"
},

// 〜
```

Clearly saying, **this is a kind of _dirty_ hack**, but better than writing every binding twice only for dispatching build profile!